### PR TITLE
Release v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic
 Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v0.2.0] - 2025-05-05
+
+### Added
+
+- Implemented `insert_template` action and mapped it to `<leader>ci` by default
+
 ## [v0.1.0] - 2025-04-26
 
 - First release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,21 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
-- Implemented `insert_template` action and mapped it to `<leader>ci` by default
+- Added new action `insert_template` which inserts a template into the currently
+  open buffer
+- Added a new configuration option named `telescope_theme`
+  - This will allow users to specify which telescope theme to use for the file
+    pickers (e.g. ivy, dropdown, cursor, or default for no theme)
+
+### Changed
+
+- Refactored theme application logic for better reusability
+  - Moved theme handling code into a separate utility module
+  - Updated all actions to use the new utility module
+- Changed the default telescope appearance for file pickers from `ivy` to no
+  theme
+  - This way the plugin does not enforce a particular theme and users can change
+    it to whatever they like
 
 ## [v0.1.0] - 2025-04-26
 

--- a/README.md
+++ b/README.md
@@ -64,17 +64,25 @@ Defaults:
   },
   config = function()
     require('compendium').setup({
+      -- Directory where your notes are stored
       landing_dir = nil,
+      -- Directory where your templates are stored
       templates_dir = nil,
+      -- When true, automatically inserts a formatted datetime header when inserting a template
+      -- Format = YYYY - MMMM DD, hh:mm
       insert_datetime_header = false,
+      -- Key mappings for plugin actions
       action_keymap = {
         create_note = "<leader>cc",
         find_notes = "<leader>cf",
         create_note_from_template = "<leader>ct",
         create_cwd_note_from_template = "<leader>cT",
-        insert_template = "<leader>ci"
+        insert_template = "<leader>ci",
       },
+      -- Whether to setup the keymaps defined in action_keymap automatically
       setup_keymaps = true,
+      -- The telescope theme to use (e.g. default (no theme), ivy (fallback), dropdown, or cursor)
+      telescope_theme = "default",
     })
   end
 }

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Using [lazy.nvim](https://github.com/folke/lazy.nvim)
 - To create a new note from a template: `<leader>ct`
 - To create a new note from a template, in the current working directory: `<leader>cT`
 - To find notes in the collection: `<leader>cf`
+- To insert a template into the currently open buffer: `<leader>ci`
 
 ## Configuration
 
@@ -71,6 +72,7 @@ Defaults:
         find_notes = "<leader>cf",
         create_note_from_template = "<leader>ct",
         create_cwd_note_from_template = "<leader>cT",
+        insert_template = "<leader>ci"
       },
       setup_keymaps = true,
     })

--- a/lua/compendium/actions/create_note_from_template.lua
+++ b/lua/compendium/actions/create_note_from_template.lua
@@ -1,11 +1,5 @@
 local get_formatted_datetime = require("compendium.utils.get_formatted_datetime")
-
-local function apply_theme(command, opts)
-  local themes = require("telescope.themes")
-  return function()
-    command(themes.get_ivy(opts))
-  end
-end
+local telescope_utils = require("compendium.utils.telescope")
 
 local function get_selected_template(opts)
   local selection = opts.telescope_actions_state.get_selected_entry()
@@ -153,7 +147,7 @@ local function create_note_from_template(opts)
     return
   end
 
-  pcall(apply_theme(telescope.find_files, {
+  local themed_find_files = telescope_utils.apply_theme(opts.telescope_theme, telescope.find_files, {
     prompt_title = "Select template",
     cwd = opts.templates_dir,
     hidden = true,
@@ -178,7 +172,16 @@ local function create_note_from_template(opts)
 
       return true
     end,
-  }))
+  })
+
+  if themed_find_files then
+    pcall(themed_find_files)
+  else
+    vim.notify(
+      "[compendium.nvim] create_note_from_template action failed: could not prepare telescope action",
+      vim.log.levels.WARN
+    )
+  end
 end
 
 return create_note_from_template

--- a/lua/compendium/actions/find_notes.lua
+++ b/lua/compendium/actions/find_notes.lua
@@ -1,9 +1,4 @@
-local function apply_theme(command, opts)
-  local themes = require("telescope.themes")
-  return function()
-    command(themes.get_ivy(opts))
-  end
-end
+local telescope_utils = require("compendium.utils.telescope")
 
 local function find_notes(opts)
   if not opts.landing_dir or opts.landing_dir == "" then
@@ -26,11 +21,17 @@ local function find_notes(opts)
     return
   end
 
-  pcall(apply_theme(telescope.find_files, {
+  local themed_find_files = telescope_utils.apply_theme(opts.telescope_theme, telescope.find_files, {
     prompt_title = "Find notes",
     cwd = opts.landing_dir,
     hidden = true,
-  }))
+  })
+
+  if themed_find_files then
+    pcall(themed_find_files)
+  else
+    vim.notify("[compendium.nvim] find_notes action failed: could not prepare telescope action", vim.log.levels.WARN)
+  end
 end
 
 return find_notes

--- a/lua/compendium/actions/insert_template.lua
+++ b/lua/compendium/actions/insert_template.lua
@@ -1,11 +1,5 @@
 local get_formatted_datetime = require("compendium.utils.get_formatted_datetime")
-
-local function apply_theme(command, opts)
-  local themes = require("telescope.themes")
-  return function()
-    command(themes.get_ivy(opts))
-  end
-end
+local telescope_utils = require("compendium.utils.telescope")
 
 local function get_selected_template(opts)
   local selection = opts.telescope_actions_state.get_selected_entry()
@@ -60,7 +54,7 @@ local function insert_template(opts)
     return
   end
 
-  pcall(apply_theme(telescope.find_files, {
+  local themed_find_files = telescope_utils.apply_theme(opts.telescope_theme, telescope.find_files, {
     prompt_title = "Select template to insert",
     cwd = opts.templates_dir,
     hidden = true,
@@ -134,7 +128,16 @@ local function insert_template(opts)
 
       return true
     end,
-  }))
+  })
+
+  if themed_find_files then
+    pcall(themed_find_files)
+  else
+    vim.notify(
+      "[compendium.nvim] insert_template action failed: could not prepare telescope action",
+      vim.log.levels.WARN
+    )
+  end
 end
 
 return insert_template

--- a/lua/compendium/data/config.lua
+++ b/lua/compendium/data/config.lua
@@ -1,7 +1,15 @@
+-- data/config.lua
+-- Default configuration for compendium.nvim
+
 local M = {
+  -- Directory where your notes are stored
   landing_dir = nil,
+  -- Directory where your templates are stored
   templates_dir = nil,
+  -- When true, automatically inserts a formatted datetime header when inserting a template
+  -- Format = YYYY - MMMM DD, hh:mm
   insert_datetime_header = false,
+  -- Key mappings for plugin actions
   action_keymap = {
     create_note = "<leader>cc",
     find_notes = "<leader>cf",
@@ -9,7 +17,10 @@ local M = {
     create_cwd_note_from_template = "<leader>cT",
     insert_template = "<leader>ci",
   },
+  -- Whether to setup the keymaps defined in action_keymap automatically
   setup_keymaps = true,
+  -- The telescope theme to use (e.g. default (no theme), ivy (fallback), dropdown, or cursor)
+  telescope_theme = "default",
 }
 
 return M

--- a/lua/compendium/init.lua
+++ b/lua/compendium/init.lua
@@ -27,7 +27,10 @@ function compendium.setup(user_config)
     },
     find_notes = {
       fn = function()
-        require("compendium.actions.find_notes")({ landing_dir = config.landing_dir })
+        require("compendium.actions.find_notes")({
+          landing_dir = config.landing_dir,
+          telescope_theme = config.telescope_theme,
+        })
       end,
       mode = "n",
       opts = {
@@ -42,6 +45,7 @@ function compendium.setup(user_config)
           landing_dir = config.landing_dir,
           templates_dir = config.templates_dir,
           insert_datetime_header = config.insert_datetime_header,
+          telescope_theme = config.telescope_theme,
         })
       end,
       mode = "n",
@@ -57,6 +61,7 @@ function compendium.setup(user_config)
           landing_dir = vim.loop.cwd(),
           templates_dir = config.templates_dir,
           insert_datetime_header = config.insert_datetime_header,
+          telescope_theme = config.telescope_theme,
         })
       end,
       mode = "n",
@@ -71,6 +76,7 @@ function compendium.setup(user_config)
         require("compendium.actions.insert_template")({
           templates_dir = config.templates_dir,
           insert_datetime_header = config.insert_datetime_header,
+          telescope_theme = config.telescope_theme,
         })
       end,
       mode = "n",

--- a/lua/compendium/utils/telescope.lua
+++ b/lua/compendium/utils/telescope.lua
@@ -1,0 +1,56 @@
+local M = {}
+
+-- Applies a specific theme to a telescope action
+function M.apply_theme(theme_name, action, action_opts)
+  local themes_ok, themes = pcall(require, "telescope.themes")
+
+  if not themes_ok then
+    vim.notify("[compendium.nvim] apply_theme failed: telescope.themes module was not found", vim.log.levels.WARN)
+    return function()
+      action(action_opts)
+    end
+  end
+
+  local default_theme_name = "ivy"
+  local effective_theme_name = theme_name or default_theme_name
+
+  if effective_theme_name == "default" then
+    return function()
+      action(action_opts)
+    end
+  end
+
+  local theme_fn = themes["get_" .. effective_theme_name]
+
+  if not theme_fn or type(theme_fn) ~= "function" then
+    vim.notify(
+      string.format(
+        "[compendium.nvim] apply_theme failed: telescope theme '%s' was not found or invalid. Falling back to '%s'",
+        effective_theme_name,
+        default_theme_name
+      ),
+      vim.log.levels.WARN
+    )
+
+    theme_fn = themes.get_ivy
+
+    if not theme_fn then
+      vim.notify(
+        string.format(
+          "[compendium.nvim] apply_theme failed: default telescope theme '%s' was not found",
+          default_theme_name
+        ),
+        vim.log.levels.ERROR
+      )
+      return function()
+        action(action_opts)
+      end
+    end
+  end
+
+  return function()
+    action(theme_fn(action_opts))
+  end
+end
+
+return M


### PR DESCRIPTION
## What's changed

### Added

- Added new action `insert_template` which inserts a template into the currently
  open buffer
- Added a new configuration option named `telescope_theme`
  - This will allow users to specify which telescope theme to use for the file
    pickers (e.g. ivy, dropdown, cursor, or default for no theme)

### Changed

- Refactored theme application logic for better reusability
  - Moved theme handling code into a separate utility module
  - Updated all actions to use the new utility module
- Changed the default telescope appearance for file pickers from `ivy` to no
  theme
  - This way the plugin does not enforce a particular theme and users can change
    it to whatever they like

## Why
- Found myself wanting to insert a template into an already open buffer multiple times, so decided to create an action for that